### PR TITLE
feat(home): expand architecture diagram with netbox-ceph, netbox-pbs, netbox-pdm, netbox-packer

### DIFF
--- a/components/home/ProjectsArchitecture.tsx
+++ b/components/home/ProjectsArchitecture.tsx
@@ -105,9 +105,9 @@ function VerticalEdge({ label }: { label?: string }) {
   );
 }
 
-function ForkConnector({ label }: { label?: string }) {
+function ForkConnector3() {
   return (
-    <div className="flex w-full max-w-md flex-col items-center">
+    <div className="flex w-full max-w-2xl flex-col items-center">
       <svg
         aria-hidden="true"
         viewBox="0 0 100 24"
@@ -116,18 +116,15 @@ function ForkConnector({ label }: { label?: string }) {
       >
         <g stroke="currentColor" strokeWidth="0.6" fill="none">
           <line x1="50" y1="0" x2="50" y2="9" />
-          <line x1="25" y1="9" x2="75" y2="9" />
-          <line x1="25" y1="9" x2="25" y2="20" />
-          <line x1="75" y1="9" x2="75" y2="20" />
-          <polyline points="23,18 25,22 27,18" />
-          <polyline points="73,18 75,22 77,18" />
+          <line x1="17" y1="9" x2="83" y2="9" />
+          <line x1="17" y1="9" x2="17" y2="20" />
+          <line x1="50" y1="9" x2="50" y2="20" />
+          <line x1="83" y1="9" x2="83" y2="20" />
+          <polyline points="15,18 17,22 19,18" />
+          <polyline points="48,18 50,22 52,18" />
+          <polyline points="81,18 83,22 85,18" />
         </g>
       </svg>
-      {label ? (
-        <span className="-mt-1 text-[10px] uppercase tracking-wider text-muted/80">
-          {label}
-        </span>
-      ) : null}
     </div>
   );
 }
@@ -146,18 +143,26 @@ export function ProjectsArchitecture() {
       <div className="flex flex-col items-center gap-1">
         <Node name="netbox" description={a.nodes.netbox} highlight logo="netbox" />
         <VerticalEdge label={a.edges.plugin} />
-        <Node
-          name="netbox-proxbox"
-          description={a.nodes.netboxProxbox}
-          href="/netbox-proxbox"
-          highlight
-        />
+
+        <div className="flex flex-wrap justify-center gap-2 w-full max-w-2xl">
+          <Node
+            name="netbox-proxbox"
+            description={a.nodes.netboxProxbox}
+            href="/netbox-proxbox"
+            highlight
+          />
+          <Node name="netbox-ceph"   description={a.nodes.netboxCeph}   highlight />
+          <Node name="netbox-pbs"    description={a.nodes.netboxPbs}    highlight />
+          <Node name="netbox-pdm"    description={a.nodes.netboxPdm}    highlight />
+          <Node name="netbox-packer" description={a.nodes.netboxPacker} highlight />
+        </div>
+
         <VerticalEdge label={a.edges.httpSseWs} />
         <Node name="proxbox-api" description={a.nodes.proxboxApi} highlight />
 
-        <ForkConnector />
+        <ForkConnector3 />
 
-        <div className="grid w-full max-w-md grid-cols-2 gap-x-4 sm:gap-x-6">
+        <div className="grid w-full max-w-2xl grid-cols-3 gap-x-4 items-start sm:gap-x-6">
           <div className="flex flex-col items-center gap-1">
             <Node
               name="netbox-sdk"
@@ -185,6 +190,15 @@ export function ProjectsArchitecture() {
               description={a.nodes.proxmoxRest}
               logo="proxmox"
             />
+          </div>
+          <div className="flex flex-col items-center gap-1">
+            <Node name="proxmox · ceph" description={a.nodes.proxmoxCeph} />
+            <VerticalEdge />
+            <Node name="proxmox · PBS"  description={a.nodes.proxmoxPbs} />
+            <VerticalEdge />
+            <Node name="proxmox · PDM"  description={a.nodes.proxmoxPdm} />
+            <VerticalEdge />
+            <Node name="packer"         description={a.nodes.hashicorpPacker} />
           </div>
         </div>
       </div>

--- a/lib/i18n/dictionary.ts
+++ b/lib/i18n/dictionary.ts
@@ -277,11 +277,19 @@ export type Dictionary = {
       nodes: {
         netbox: string;
         netboxProxbox: string;
+        netboxCeph: string;
+        netboxPbs: string;
+        netboxPdm: string;
+        netboxPacker: string;
         proxboxApi: string;
         netboxSdk: string;
         netboxRest: string;
         proxmoxSdk: string;
         proxmoxRest: string;
+        proxmoxCeph: string;
+        proxmoxPbs: string;
+        proxmoxPdm: string;
+        hashicorpPacker: string;
       };
     };
     contact: {
@@ -599,11 +607,19 @@ const en: Dictionary = {
       nodes: {
         netbox: "Open-source source-of-truth platform for network infrastructure (DCIM / IPAM / virtualization).",
         netboxProxbox: "NetBox plugin that surfaces Proxmox infra (clusters, nodes, VMs, backups) inside NetBox and triggers syncs.",
+        netboxCeph: "NetBox plugin that syncs Proxmox Ceph storage pool and health data into NetBox.",
+        netboxPbs: "NetBox plugin that surfaces Proxmox Backup Server job history and datastore status in NetBox.",
+        netboxPdm: "NetBox plugin that integrates Proxmox Datacenter Manager inventory and cross-cluster views into NetBox.",
+        netboxPacker: "NetBox plugin that tracks HashiCorp Packer build metadata and provisioned image records in NetBox.",
         proxboxApi: "FastAPI backend that orchestrates the NetBox ↔ Proxmox sync workflow over HTTP, SSE, and WebSocket.",
         netboxSdk: "Python async SDK + CLI (nbx) + Textual TUI for the NetBox REST API. Used by proxbox-api to read/write NetBox.",
         netboxRest: "NetBox's REST API — the data target where Proxmox infrastructure ends up.",
         proxmoxSdk: "Schema-driven FastAPI SDK for the Proxmox VE API: 646 generated endpoints, dual mock/real modes, CLI + TUI.",
         proxmoxRest: "Proxmox VE's REST API — the data source for clusters, nodes, VMs, storage, and backups.",
+        proxmoxCeph: "Proxmox Ceph REST API — distributed storage cluster integrated directly with Proxmox VE nodes.",
+        proxmoxPbs: "Proxmox Backup Server REST API — deduplicating backup service for VMs, containers, and hosts.",
+        proxmoxPdm: "Proxmox Datacenter Manager REST API — centralized multi-cluster inventory and task orchestration.",
+        hashicorpPacker: "HashiCorp Packer API — image-build pipeline producing Proxmox VM templates and cloud images.",
       },
     },
     contact: {
@@ -923,11 +939,19 @@ const ptBr: Dictionary = {
       nodes: {
         netbox: "Plataforma open-source de fonte da verdade para infraestrutura de rede (DCIM / IPAM / virtualização).",
         netboxProxbox: "Plugin do NetBox que expõe a infraestrutura do Proxmox (clusters, nós, VMs, backups) dentro do NetBox e dispara sincronizações.",
+        netboxCeph: "Plugin do NetBox que sincroniza pools de armazenamento e dados de saúde do Proxmox Ceph no NetBox.",
+        netboxPbs: "Plugin do NetBox que exibe o histórico de jobs e o status dos datastores do Proxmox Backup Server no NetBox.",
+        netboxPdm: "Plugin do NetBox que integra o inventário do Proxmox Datacenter Manager e visões cross-cluster no NetBox.",
+        netboxPacker: "Plugin do NetBox que registra metadados de builds do HashiCorp Packer e imagens provisionadas no NetBox.",
         proxboxApi: "Backend FastAPI que orquestra o fluxo de sincronização NetBox ↔ Proxmox via HTTP, SSE e WebSocket.",
         netboxSdk: "SDK Python assíncrono + CLI (nbx) + TUI Textual para a API REST do NetBox. Usado pelo proxbox-api para ler e gravar no NetBox.",
         netboxRest: "API REST do NetBox — o destino onde a infraestrutura do Proxmox é registrada.",
         proxmoxSdk: "SDK FastAPI orientado a schema para a API do Proxmox VE: 646 endpoints gerados, modos mock/real, CLI + TUI.",
         proxmoxRest: "API REST do Proxmox VE — a fonte de dados de clusters, nós, VMs, storage e backups.",
+        proxmoxCeph: "API REST do Proxmox Ceph — cluster de armazenamento distribuído integrado diretamente aos nós do Proxmox VE.",
+        proxmoxPbs: "API REST do Proxmox Backup Server — serviço de backup com deduplicação para VMs, contêineres e hosts.",
+        proxmoxPdm: "API REST do Proxmox Datacenter Manager — inventário centralizado de múltiplos clusters e orquestração de tarefas.",
+        hashicorpPacker: "API do HashiCorp Packer — pipeline de build de imagens que gera templates de VM para Proxmox e imagens cloud.",
       },
     },
     contact: {


### PR DESCRIPTION
## Summary

- Adds four new NetBox plugin nodes to the plugin row alongside `netbox-proxbox`: **netbox-ceph**, **netbox-pbs**, **netbox-pdm**, **netbox-packer**
- Adds a third column in the bottom fork showing the four external service endpoints proxbox-api connects to: **Proxmox Ceph**, **Proxmox Backup Server (PBS)**, **Proxmox Datacenter Manager (PDM)**, **HashiCorp Packer**
- Replaces the 2-branch `ForkConnector` SVG with a new 3-branch `ForkConnector3` and widens the bottom grid from `grid-cols-2 max-w-md` to `grid-cols-3 max-w-2xl`
- Adds 8 new i18n node strings in both EN and PT-BR (`dictionary.ts`)

## Test plan

- [ ] Homepage renders with 5 plugin nodes in the flex-wrap row (wraps on narrow screens)
- [ ] 3-column bottom grid shows netbox-sdk chain, proxmox-sdk chain, and the 4 stacked service leaves
- [ ] Tooltip hover shows correct text for all new nodes in English and Portuguese
- [ ] `pnpm typecheck` passes — `Dictionary` type extended with new node keys
- [ ] Light and dark mode render correctly (no hex literals introduced)