### PR TITLE
Serve netbox-proxbox docs under personal domain

### DIFF
--- a/app/netbox-proxbox/docs/[[...path]]/route.ts
+++ b/app/netbox-proxbox/docs/[[...path]]/route.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from "next/server";
+
+const DOCS_PATH_PREFIX = "/netbox-proxbox/docs";
+const PUBLIC_DOCS_BASE = "https://emersonfelipesp.com/netbox-proxbox/docs";
+const UPSTREAM_DOCS_BASE = "https://emersonfelipesp.github.io/netbox-proxbox";
+const CACHE_CONTROL =
+  "public, max-age=600, s-maxage=600, stale-while-revalidate=300";
+const ERROR_CACHE_CONTROL = "no-store";
+
+const FORWARDED_REQUEST_HEADERS = [
+  "accept",
+  "accept-language",
+  "if-modified-since",
+  "if-none-match",
+  "range",
+] as const;
+
+const PASSTHROUGH_RESPONSE_HEADERS = [
+  "accept-ranges",
+  "content-type",
+  "etag",
+  "last-modified",
+] as const;
+
+function upstreamUrl(request: NextRequest): URL {
+  const pathname = request.nextUrl.pathname;
+  const suffix = pathname.slice(DOCS_PATH_PREFIX.length) || "/";
+  const url = new URL(`${UPSTREAM_DOCS_BASE}${suffix}`);
+  url.search = request.nextUrl.search;
+  return url;
+}
+
+function forwardedHeaders(request: NextRequest): Headers {
+  const headers = new Headers();
+  for (const key of FORWARDED_REQUEST_HEADERS) {
+    const value = request.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+  return headers;
+}
+
+function responseHeaders(upstream: Response, cacheable: boolean): Headers {
+  const headers = new Headers();
+  for (const key of PASSTHROUGH_RESPONSE_HEADERS) {
+    const value = upstream.headers.get(key);
+    if (value) headers.set(key, value);
+  }
+  headers.set("cache-control", cacheable ? CACHE_CONTROL : ERROR_CACHE_CONTROL);
+  return headers;
+}
+
+function isHtml(upstream: Response): boolean {
+  return upstream.headers.get("content-type")?.includes("text/html") ?? false;
+}
+
+function rewriteHtml(html: string): string {
+  return html
+    .replaceAll(`${UPSTREAM_DOCS_BASE}/`, `${PUBLIC_DOCS_BASE}/`)
+    .replaceAll(UPSTREAM_DOCS_BASE, PUBLIC_DOCS_BASE)
+    .replaceAll('href="/netbox-proxbox/', 'href="/netbox-proxbox/docs/')
+    .replaceAll('src="/netbox-proxbox/', 'src="/netbox-proxbox/docs/')
+    .replace(/^\s*<meta name="robots" content="noindex">\s*$/gim, "");
+}
+
+async function proxyDocs(request: NextRequest): Promise<Response> {
+  let upstream: Response;
+  try {
+    upstream = await fetch(upstreamUrl(request), {
+      cache: "no-store",
+      headers: forwardedHeaders(request),
+      method: request.method,
+      redirect: "follow",
+    });
+  } catch {
+    return new Response("Unable to reach netbox-proxbox documentation.", {
+      headers: { "cache-control": ERROR_CACHE_CONTROL },
+      status: 502,
+    });
+  }
+
+  const headers = responseHeaders(upstream, upstream.ok);
+
+  if (
+    request.method === "HEAD" ||
+    upstream.status === 204 ||
+    upstream.status === 304
+  ) {
+    return new Response(null, { headers, status: upstream.status });
+  }
+
+  if (isHtml(upstream)) {
+    headers.delete("etag");
+    headers.set("content-type", "text/html; charset=utf-8");
+    return new Response(rewriteHtml(await upstream.text()), {
+      headers,
+      status: upstream.status,
+    });
+  }
+
+  return new Response(upstream.body, {
+    headers,
+    status: upstream.status,
+  });
+}
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyDocs(request);
+}
+
+export async function HEAD(request: NextRequest): Promise<Response> {
+  return proxyDocs(request);
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -66,6 +66,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       ...(project.slug === "netbox-proxbox"
         ? [
             {
+              url: absolute("/netbox-proxbox/docs/"),
+              lastModified: projectModified ?? undefined,
+              changeFrequency: "weekly" as const,
+              priority: 0.85,
+            },
+            {
               url: absolute("/netbox-proxbox/community"),
               lastModified: new Date(),
               changeFrequency: "daily" as const,

--- a/content/netbox-proxbox-developer.ts
+++ b/content/netbox-proxbox-developer.ts
@@ -153,7 +153,7 @@ export const netboxProxboxDeveloper: DeveloperContent = {
   },
   links: {
     repo: "https://github.com/emersonfelipesp/netbox-proxbox",
-    docs: "https://emersonfelipesp.github.io/netbox-proxbox/",
+    docs: "https://emersonfelipesp.com/netbox-proxbox/docs/",
     backendRepo: "https://github.com/emersonfelipesp/proxbox-api",
     issues: "https://github.com/emersonfelipesp/netbox-proxbox/issues",
     contributing:

--- a/content/netbox-proxbox.ts
+++ b/content/netbox-proxbox.ts
@@ -43,7 +43,7 @@ export const netboxProxbox = {
   },
   links: {
     repo: project.repoUrl,
-    docs: "https://emersonfelipesp.github.io/netbox-proxbox/",
+    docs: "https://emersonfelipesp.com/netbox-proxbox/docs/",
     backendRepo: "https://github.com/emersonfelipesp/proxbox-api",
     "Proxmox Forum":
       "https://forum.proxmox.com/threads/proxbox-netbox-plugin-for-syncing-proxmox-ve-inventory-into-netbox.183646/",

--- a/e2e/docs-proxy.spec.ts
+++ b/e2e/docs-proxy.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+
+test("netbox-proxbox docs root renders from the first-party path", async ({
+  page,
+  request,
+}) => {
+  const redirect = await request.get("/netbox-proxbox/docs", {
+    maxRedirects: 0,
+  });
+  expect(redirect.status()).toBe(308);
+  expect(redirect.headers().location).toMatch(/\/netbox-proxbox\/docs\/$/);
+
+  const response = await request.get("/netbox-proxbox/docs/");
+  expect(response.status()).toBe(200);
+  const html = await response.text();
+  expect(html).toContain("Proxbox Docs");
+  expect(html).toContain("https://emersonfelipesp.com/netbox-proxbox/docs/");
+  expect(html).not.toContain('content="noindex"');
+
+  await page.goto("/netbox-proxbox/docs/");
+  await expect(page).toHaveTitle(/Proxbox Docs/);
+  await expect(page.getByRole("heading", { name: "Proxbox" })).toBeVisible();
+});
+
+test("netbox-proxbox docs nested pages and assets are proxied", async ({
+  page,
+  request,
+}) => {
+  const nestedRedirect = await request.get("/netbox-proxbox/docs/installation", {
+    maxRedirects: 0,
+  });
+  expect(nestedRedirect.status()).toBe(308);
+  expect(nestedRedirect.headers().location).toMatch(
+    /\/netbox-proxbox\/docs\/installation\/$/,
+  );
+
+  await page.goto("/netbox-proxbox/docs/installation/");
+  await expect(page).toHaveTitle(/Overview - Proxbox Docs/);
+  await expect(
+    page.getByRole("heading", { name: "Installation" }).first(),
+  ).toBeVisible();
+
+  const searchIndex = await request.get(
+    "/netbox-proxbox/docs/search/search_index.json",
+  );
+  expect(searchIndex.status()).toBe(200);
+  expect(searchIndex.headers()["content-type"]).toContain("application/json");
+  expect(await searchIndex.text()).toContain("Proxbox");
+});
+
+test("non-doc routes keep no-trailing-slash behavior", async ({ request }) => {
+  const response = await request.get("/netbox-sdk/", { maxRedirects: 0 });
+  expect(response.status()).toBe(308);
+  expect(response.headers().location).toMatch(/\/netbox-sdk$/);
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,12 @@ const nextConfig = require("eslint-config-next");
 module.exports = [
   ...nextConfig,
   {
-    ignores: [".next/**", "node_modules/**", "playwright-report/**", "test-results/**"],
+    ignores: [
+      ".claude/**",
+      ".next/**",
+      "node_modules/**",
+      "playwright-report/**",
+      "test-results/**",
+    ],
   },
 ];

--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const markdownAcceptHeader = [
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   htmlLimitedBots: /.*/i,
+  skipTrailingSlashRedirect: true,
   allowedDevOrigins: ["10.0.30.207"],
   async headers() {
     return [

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const DOCS_PATH_PREFIX = "/netbox-proxbox/docs";
+const STATIC_FILE_EXTENSION =
+  /\.(?:avif|br|css|eot|gif|gz|ico|jpeg|jpg|js|json|map|mjs|pdf|png|svg|ttf|txt|webp|woff|woff2|xml|yaml|yml|zip)$/i;
+
+function isDocsPath(pathname: string): boolean {
+  return (
+    pathname === DOCS_PATH_PREFIX || pathname.startsWith(`${DOCS_PATH_PREFIX}/`)
+  );
+}
+
+function isStaticFilePath(pathname: string): boolean {
+  return STATIC_FILE_EXTENSION.test(pathname);
+}
+
+function redirectTo(request: NextRequest, pathname: string): NextResponse {
+  const url = new URL(request.url);
+  url.pathname = pathname;
+  return NextResponse.redirect(url, 308);
+}
+
+export function proxy(request: NextRequest): NextResponse {
+  const { pathname } = request.nextUrl;
+
+  if (isDocsPath(pathname)) {
+    if (!pathname.endsWith("/") && !isStaticFilePath(pathname)) {
+      return redirectTo(request, `${pathname}/`);
+    }
+    return NextResponse.next();
+  }
+
+  if (pathname !== "/" && pathname.endsWith("/")) {
+    return redirectTo(request, pathname.replace(/\/+$/, ""));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};


### PR DESCRIPTION
Closes #9

## Summary
- proxy the MkDocs GitHub Pages output at `/netbox-proxbox/docs/` while preserving docs navigation and assets under the personal domain
- add Next 16 proxy-based slash normalization so docs directories keep trailing slashes and app routes keep the existing no-trailing-slash behavior
- update netbox-proxbox docs links and sitemap entry to point at the first-party docs URL
- add Playwright coverage for docs root, nested pages, assets, and non-doc slash behavior

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec playwright test e2e/docs-proxy.spec.ts --project=desktop-chromium`