### PR TITLE
Add docs action icon to netbox-proxbox page

### DIFF
--- a/components/nav/NavActions.tsx
+++ b/components/nav/NavActions.tsx
@@ -2,9 +2,10 @@
 
 import { ReleasesDropdown } from "./ReleasesDropdown";
 import type { GitHubReleaseSummary } from "@/lib/github";
+import type { ProjectActionIcon } from "@/lib/project-registry";
 
 export type SectionAction = {
-  icon: "github" | "pypi" | "docker";
+  icon: ProjectActionIcon;
   href: string;
   label: string;
 };
@@ -70,6 +71,27 @@ function PyPIIcon({ className }: { className?: string }) {
   );
 }
 
+function DocsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="1.8"
+      className={className}
+    >
+      <path d="M6.75 3.75h6l4.5 4.5v12H6.75z" />
+      <path d="M12.75 3.75v4.5h4.5" />
+      <path d="M9.25 12h5.5" />
+      <path d="M9.25 15.25h5.5" />
+      <path d="M9.25 18.5h3.5" />
+    </svg>
+  );
+}
+
 function DockerIcon({ className }: { className?: string }) {
   return (
     <svg
@@ -87,6 +109,7 @@ const ICONS = {
   github: GitHubIcon,
   pypi: PyPIIcon,
   docker: DockerIcon,
+  docs: DocsIcon,
 } as const;
 
 export function NavActions({

--- a/components/nav/project-shell-labels.ts
+++ b/components/nav/project-shell-labels.ts
@@ -10,13 +10,14 @@ export function useProjectShellActions(
   const { t } = useLanguage();
   const meta = getProjectShellMeta(slug);
   if (!meta) return [];
+  const actionLabels = {
+    github: t.project.actions.github,
+    pypi: t.project.actions.pypi,
+    docker: t.project.actions.docker,
+    docs: t.project.actions.docs,
+  } as const;
   return meta.actions.map((a) => ({
     ...a,
-    label:
-      a.icon === "github"
-        ? t.project.actions.github
-        : a.icon === "pypi"
-          ? t.project.actions.pypi
-          : t.project.actions.docker,
+    label: actionLabels[a.icon],
   }));
 }

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -12,6 +12,10 @@ test("/netbox-proxbox loads", async ({ page }) => {
   await expect(page).toHaveURL("/netbox-proxbox");
   await expect(page.locator("main")).toBeVisible();
   await expect(page.getByRole("navigation", { name: "Top navigation" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "View documentation" })).toHaveAttribute(
+    "href",
+    "https://emersonfelipesp.com/netbox-proxbox/docs/",
+  );
 });
 
 test("/netbox-sdk loads", async ({ page }) => {

--- a/lib/i18n/dictionary.ts
+++ b/lib/i18n/dictionary.ts
@@ -48,6 +48,7 @@ export type Dictionary = {
       github: string;
       pypi: string;
       docker: string;
+      docs: string;
       stars: (project: string) => string;
       releases: (project: string) => string;
     };
@@ -389,6 +390,7 @@ const en: Dictionary = {
       github: "View source on GitHub",
       pypi: "View package on PyPI",
       docker: "View image on Docker Hub",
+      docs: "View documentation",
       stars: (project) => `Star ${project} on GitHub`,
       releases: (project) => `Releases of ${project}`,
     },
@@ -754,6 +756,7 @@ const ptBr: Dictionary = {
       github: "Ver código-fonte no GitHub",
       pypi: "Ver pacote no PyPI",
       docker: "Ver imagem no Docker Hub",
+      docs: "Ver documentação",
       stars: (project) => `Dar estrela em ${project} no GitHub`,
       releases: (project) => `Versões de ${project}`,
     },

--- a/lib/markdown/routes.ts
+++ b/lib/markdown/routes.ts
@@ -4,6 +4,7 @@ import {
   getProject,
   isProjectSlug,
   PROJECT_LIST,
+  type ProjectActionIcon,
   type ProjectSlug,
   releaseDetailPath,
   releaseListPath,
@@ -42,6 +43,13 @@ import {
   renderReleaseListPage,
 } from "./release-pages";
 import { renderRoadmapPage } from "./roadmap-pages";
+
+const PROJECT_ACTION_LABELS = {
+  github: "GitHub",
+  docs: "Docs",
+  pypi: "PyPI",
+  docker: "Docker Hub",
+} satisfies Record<ProjectActionIcon, string>;
 
 export async function getMarkdownForPath(
   pathname: string,
@@ -270,13 +278,7 @@ export async function getLlmsTxt(): Promise<string> {
       PROJECT_LIST.map((project) => {
         const actionLines = project.actions
           .map((action) => {
-            const label =
-              action.icon === "github"
-                ? "GitHub"
-                : action.icon === "pypi"
-                  ? "PyPI"
-                  : "Docker Hub";
-            return `  - ${label}: ${action.href}`;
+            return `  - ${PROJECT_ACTION_LABELS[action.icon]}: ${action.href}`;
           })
           .join("\n");
         return [
@@ -343,6 +345,7 @@ export async function getProjectLlmsTxt(
     ["Developer guide", absolute(developerPath)],
     ["Roadmap", absolute(roadmapHref)],
     ["Release index", absolute(releasesIndexPath)],
+    ["Docs", projectActionsMap.get("docs") ?? null],
     ["PyPI", projectActionsMap.get("pypi") ?? null],
     ["Docker Hub", projectActionsMap.get("docker") ?? null],
     ["License", content.meta.license ?? null],

--- a/lib/project-registry.ts
+++ b/lib/project-registry.ts
@@ -1,5 +1,5 @@
 export type Palette = "netbox" | "proxmox" | "mixed";
-export type ProjectActionIcon = "github" | "pypi" | "docker";
+export type ProjectActionIcon = "github" | "pypi" | "docker" | "docs";
 
 export type ProjectSlug =
   | "netbox-proxbox"
@@ -49,6 +49,10 @@ export const PROJECTS = {
       {
         icon: "github",
         href: "https://github.com/emersonfelipesp/netbox-proxbox",
+      },
+      {
+        icon: "docs",
+        href: "https://emersonfelipesp.com/netbox-proxbox/docs/",
       },
       { icon: "pypi", href: "https://pypi.org/project/netbox-proxbox/" },
     ],


### PR DESCRIPTION
Closes #11

## Summary
- adds a first-party docs action URL for netbox-proxbox in the project registry
- renders the docs action with a shared document icon next to the existing GitHub and PyPI icons
- adds localized accessible labels and includes the docs action in generated markdown/link metadata
- verifies the /netbox-proxbox page exposes the docs action link

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm exec playwright test e2e/smoke.spec.ts --project=desktop-chromium --grep "/netbox-proxbox loads"